### PR TITLE
Add #include <limits> to resolve build issue

### DIFF
--- a/srtcore/sync.h
+++ b/srtcore/sync.h
@@ -24,6 +24,7 @@
 #include <pthread.h>
 #endif
 #include "utilities.h"
+#include <limits>
 
 class CUDTException;    // defined in common.h
 


### PR DESCRIPTION
Updates compatibility with newer Ubuntu releases.  
Now builds on newer Ubuntu releases such as Ubuntu 22.10